### PR TITLE
WIP: Omit certain paths from mocking

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -7,7 +7,7 @@ on:
     push:
         branches: [master]
     pull_request:
-        branches: [master]
+        branches: ['*']
 
 jobs:
     build:

--- a/README.md
+++ b/README.md
@@ -142,32 +142,33 @@ test('Sign-up form', async () => {
 
 ### URL and method matching <a name="url-and-method-matching"/>
 
-Request can be matched by:
+Request can most easily be mocked by calling `mockiavelli.mock<HTTP_METHOD>` with endpoint URL:
 
--   providing URL string to `mockiavelli.mock<HTTP_METHOD>` method:
+```typescript
+mockiavelli.mockGET('/api/users', { status: 200, body: [] });
+// GET /api/users => 200
 
-    ```typescript
-    mockiavelli.mockGET('/api/users?age=30', {status: 200, body: [....]})
-    ```
+mockiavelli.mockPOST('/api/users', { status: 201 });
+// POST /api/users => 200
+```
 
--   providing matcher object to `mockiavelli.mock<HTTP_METHOD>` method
+Alternatively you can provide HTTP method and URL as object to `mockiavelli.mock`:
 
-    ```typescript
-    mockiavelli.mockGET({
-        url: '/api/users',
-        query: { age: '30' }
-    }, {status: 200, body: [....]})
-    ```
+```typescript
+mockiavelli.mock(
+    { method: 'GET', url: '/api/users' },
+    { status: 200, body: [] }
+);
+// GET /api/users => 200
+```
 
--   providing full matcher object `mockiavelli.mock` method
+If HTTP method is not specified, any request that matches provided URL will be mocked.
 
-    ```typescript
-    mockiavelli.mock({
-        method: 'GET',
-        url: '/api/users',
-        query: { age: '30' }
-    }, {status: 200, body: [...]})
-    ```
+```typescript
+mockiavelli.mock('/api/users', { status: 500 });
+// GET /api/users => 500
+// POST /api/users => 500
+```
 
 ### Path parameters matching <a name="path-parameters-matching"/>
 
@@ -185,8 +186,6 @@ const getUserMock = mockiavelli.mockGET('/api/users/:userId', { status: 200 });
 console.log(await getUserMock.waitForRequest());
 // { params: {userId : "12345"}, path: "/api/users/12345", ... }
 ```
-
-Mockiavelli uses
 
 ### Query params matching <a name="query-parameters-matching"/>
 
@@ -406,9 +405,9 @@ Respond all requests of matching `matcher` with provided `response`.
 
 ###### Arguments
 
--   `matcher` _(object)_ matches request with mock.
-    -   `method: string` - any valid HTTP method
+-   `matcher` _(string | object)_ URL string or object with following properties:
     -   `url: string` - can be provided as path (`/api/endpoint`) or full URL (`http://example.com/endpoint`) for CORS requests. Supports path parameters (`/api/users/:user_id`)
+    -   `method?: string` - any valid HTTP method. If not provided, will match any HTTP method.
     -   `query?: object` object literal which accepts strings and arrays of strings as values, transformed to queryString
 -   `response` _(object | function)_ content of mocked response. Can be a object or a function returning object with following properties:
     -   `status: number`

--- a/src/mock.ts
+++ b/src/mock.ts
@@ -7,6 +7,7 @@ import {
     MockedResponseObject,
     RequestMatcher,
     PathParameters,
+    MatcherHttpMethod,
 } from './types';
 import { waitFor, TimeoutError, nth } from './utils';
 import isEqual from 'lodash.isequal';
@@ -23,7 +24,7 @@ let debugId = 1;
 
 export class Mock {
     private matcher: {
-        method: string;
+        method: MatcherHttpMethod;
         hostname: string | undefined;
         path: string;
         query: QueryObject;
@@ -135,7 +136,10 @@ export class Mock {
     }
 
     private getRequestMatch(request: BrowserRequest): MatchedRequest | null {
-        if (request.method !== this.matcher.method) {
+        if (
+            request.method !== this.matcher.method &&
+            this.matcher.method !== 'ALL'
+        ) {
             this.debugMiss('method', request.method, this.matcher.method);
             return null;
         }

--- a/src/mockiavelli.ts
+++ b/src/mockiavelli.ts
@@ -14,6 +14,7 @@ import {
     MockOptions,
     RequestMatcher,
     ShorthandRequestMatcher,
+    URLString,
 } from './types';
 import {
     addMockByPriority,
@@ -72,13 +73,14 @@ export class Mockiavelli {
     }
 
     public mock<TResponseBody = any>(
-        matcher: RequestMatcher,
+        matcher: RequestMatcher | URLString,
         response: MockedResponse<TResponseBody>,
         options?: Partial<MockOptions>
     ): Mock {
+        const matcherObj = createRequestMatcher(matcher, 'ALL');
         const matcherWithBaseUrl = {
-            ...matcher,
-            url: this.baseUrl + matcher.url,
+            ...matcherObj,
+            url: this.baseUrl + matcherObj.url,
         };
         const mock = new Mock(matcherWithBaseUrl, response, { ...options });
         addMockByPriority(this.mocks, mock);
@@ -86,7 +88,7 @@ export class Mockiavelli {
     }
 
     public mockGET<TResponseBody = any>(
-        matcher: ShorthandRequestMatcher,
+        matcher: ShorthandRequestMatcher | URLString,
         response: MockedResponse<TResponseBody>,
         options?: Partial<MockOptions>
     ): Mock {
@@ -98,7 +100,7 @@ export class Mockiavelli {
     }
 
     public mockPOST<TResponseBody = any>(
-        matcher: ShorthandRequestMatcher,
+        matcher: ShorthandRequestMatcher | URLString,
         response: MockedResponse<TResponseBody>,
         options?: Partial<MockOptions>
     ): Mock {
@@ -110,7 +112,7 @@ export class Mockiavelli {
     }
 
     public mockPUT<TResponseBody = any>(
-        matcher: ShorthandRequestMatcher,
+        matcher: ShorthandRequestMatcher | URLString,
         response: MockedResponse<TResponseBody>,
         options?: Partial<MockOptions>
     ): Mock {
@@ -122,7 +124,7 @@ export class Mockiavelli {
     }
 
     public mockDELETE<TResponseBody = any>(
-        matcher: ShorthandRequestMatcher,
+        matcher: ShorthandRequestMatcher | URLString,
         response: MockedResponse<TResponseBody>,
         options?: Partial<MockOptions>
     ): Mock {
@@ -134,7 +136,7 @@ export class Mockiavelli {
     }
 
     public mockPATCH<TResponseBody = any>(
-        matcher: ShorthandRequestMatcher,
+        matcher: ShorthandRequestMatcher | URLString,
         response: MockedResponse<TResponseBody>,
         options?: Partial<MockOptions>
     ): Mock {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,19 +1,19 @@
 export type QueryObject = Record<string, string | string[] | undefined>;
 
-export interface RequestMatcher {
-    method: HttpMethod;
-    url: string;
+export type URLString = string;
+
+export type RequestMatcher = {
+    method: MatcherHttpMethod;
+    url: URLString;
     query?: QueryObject;
     body?: any;
-}
+};
 
-export type ShorthandRequestMatcher =
-    | {
-          url: string;
-          query?: QueryObject;
-          body?: any;
-      }
-    | string;
+export type ShorthandRequestMatcher = {
+    url: URLString;
+    query?: QueryObject;
+    body?: any;
+};
 
 export type MockedResponse<TResponseBody = any> =
     | ((req: MatchedRequest) => MockedResponseObject<TResponseBody>)
@@ -43,3 +43,11 @@ export interface MockOptions {
 }
 
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+
+export type MatcherHttpMethod =
+    | 'ALL'
+    | 'GET'
+    | 'POST'
+    | 'PUT'
+    | 'DELETE'
+    | 'PATCH';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,9 @@
-import { HttpMethod, RequestMatcher, ShorthandRequestMatcher } from './types';
+import {
+    MatcherHttpMethod,
+    RequestMatcher,
+    ShorthandRequestMatcher,
+    URLString,
+} from './types';
 import { BrowserRequest } from './controllers/BrowserController';
 import { parse } from 'url';
 
@@ -62,8 +67,8 @@ export function addMockByPriority<T extends { options: { priority: number } }>(
 }
 
 export function createRequestMatcher(
-    input: ShorthandRequestMatcher,
-    method: HttpMethod
+    input: ShorthandRequestMatcher | RequestMatcher | URLString,
+    method: MatcherHttpMethod
 ): RequestMatcher {
     if (typeof input === 'string') {
         return {

--- a/test/integration/mockiavelli.int.test.ts
+++ b/test/integration/mockiavelli.int.test.ts
@@ -25,6 +25,15 @@ describe(`Mockiavelli integration [${TEST_LIBRARY}]`, () => {
     });
 
     test.each(METHODS)(
+        `matches %s request when using .mock('/path')`,
+        async (METHOD) => {
+            ctx.mockiavelli.mock('/example', { status: 200 });
+            const result = await ctx.makeRequest(METHOD, '/example');
+            expect(result.status).toEqual(200);
+        }
+    );
+
+    test.each(METHODS)(
         'matches request with .mock%s() method and URL string',
         async (METHOD) => {
             ctx.mockiavelli[('mock' + METHOD) as Methods]('/example', {
@@ -63,7 +72,7 @@ describe(`Mockiavelli integration [${TEST_LIBRARY}]`, () => {
             { method: 'GET', url: '/example' },
             { status: 200, body: 'ok' }
         );
-        const response = await ctx.makeRequest('POST', '/example?param=value');
+        const response = await ctx.makeRequest('POST', '/example');
         expect(response.body).not.toEqual('ok');
     });
 


### PR DESCRIPTION
This PR will introduce `mockiavelli.passThrough` method, that gives user the ability to define which endpoints should not be mocked  (requested in #10 ):

```typescript
mockiavelli.passThrough('/do/not/mock');
```

Any request that matches the URL will be forwarded to the original endpoint using `request.continue()` / `route.continue()` methods from ppter/playwright APIs.

It will work very similar to existing `mockiavelli.mock` methods and use the same underlying request matching mechanism. User will be able to mix and override `mockiavelli.passThrough` with `mockiavelli.mock`

```typescript
// do not mock any endpoint under /foo 
mockiavelli.passThrough('/foo/**/*'); 

// mock particular /foo/bar endpoint
mockiavelli.mockGET('/foo/bar', {status: 200, body: []});
```

Few internal improvements are required in order to make this method more user-friendly:
- [ ] support for matching request of any method when only URL is provided - #30 
- [ ] support for wildcard parameters `/api/**/*`, `**/*.js` 

